### PR TITLE
Support decaying the FSS counters by a factor (#3)

### DIFF
--- a/src/topk/mod.rs
+++ b/src/topk/mod.rs
@@ -123,6 +123,14 @@ impl<T: Eq + Hash> FilteredSpaceSaving<T> {
             })
     }
 
+    /// Estimates the occurrences of the item `x` if the item is in the Top-K approximation.
+    /// Otherwise, `None` is returned
+    ///
+    /// Computes in **O(1)** time.
+    pub fn get(&self, x: &T) -> Option<ElementCounter> {
+        self.monitored_list.get(x).map_or(None, |(_, v)| Some(v.0))
+    }
+
     /// Merges with `other` filtered space-saving approximation.
     ///
     /// Require `T` to implement `Clone`.
@@ -173,7 +181,7 @@ impl<T: Eq + Hash> FilteredSpaceSaving<T> {
 
     /// Decays the counters, equivalent to multiplying all counters by the factor.
     ///
-    /// Computes in **O(1)** time.
+    /// Computes in **O(k)** time.
     pub fn decay(&mut self, factor: f64) {
         for (_, value) in self.monitored_list.iter_mut() {
             value.0.estimated_count = (value.0.estimated_count as f64 * factor) as u64;

--- a/src/topk/mod.rs
+++ b/src/topk/mod.rs
@@ -218,16 +218,6 @@ impl<T: Eq + Hash> FilteredSpaceSaving<T> {
         self.into_sorted_vec().into_iter()
     }
 
-    /// Returns a sorted vector of all items (does not consume the FSS)
-    ///
-    /// Computes in **O(k*log(k))** time.
-    pub fn sorted_items_vec(&self) -> Vec<(&T, &ElementCounter)> {
-        let mut result = Vec::with_capacity(self.monitored_list.len());
-        result.extend(self.monitored_list.iter().map(|(k, v)| (k, &v.0)));
-        result.sort_by(|a, b| b.1.cmp(&a.1));
-        result
-    }
-
     /// Returns count of all seen items (sum of all inserted `count`).
     ///
     /// Computes in **O(1)** time.
@@ -235,7 +225,7 @@ impl<T: Eq + Hash> FilteredSpaceSaving<T> {
         self.count
     }
 
-    /// Returns the `k` value configured fot the FSS
+    /// Returns the `k` value configured for the FSS
     pub fn k(&self) -> usize {
         self.k
     }
@@ -351,7 +341,10 @@ mod tests {
     }
 
     fn topk_of<'a>(fss: &'a FilteredSpaceSaving<&str>) -> Vec<(&'a str, u64)> {
-        fss.sorted_items_vec().iter().map(|(&name, &counter)| (name, counter.estimated_count())).collect::<Vec<_>>()
+        let mut result = Vec::with_capacity(fss.monitored_list.len());
+        result.extend(fss.monitored_list.iter().map(|(k, v)| (k, &v.0)));
+        result.sort_by(|a, b| b.1.cmp(&a.1));
+        result.iter().map(|(&name, &counter)| (name, counter.estimated_count())).collect::<Vec<_>>()
     }
 
     #[test]

--- a/src/topk/mod.rs
+++ b/src/topk/mod.rs
@@ -124,7 +124,7 @@ impl<T: Eq + Hash> FilteredSpaceSaving<T> {
     }
 
     /// Estimates the occurrences of the item `x` if the item is in the Top-K approximation.
-    /// Otherwise, `None` is returned
+    /// Otherwise, `None` is returned.
     ///
     /// Computes in **O(1)** time.
     pub fn get(&self, x: &T) -> Option<ElementCounter> {
@@ -225,7 +225,7 @@ impl<T: Eq + Hash> FilteredSpaceSaving<T> {
         self.count
     }
 
-    /// Returns the `k` value configured for the FSS
+    /// Returns the `k` value of the counter.
     pub fn k(&self) -> usize {
         self.k
     }


### PR DESCRIPTION
add `sorted_items_vec` that does not consume the FSS